### PR TITLE
Remove dir flip from harmonics shader

### DIFF
--- a/gsplat_plugin/shaders/GSplatShaderCoreLib.h
+++ b/gsplat_plugin/shaders/GSplatShaderCoreLib.h
@@ -131,8 +131,6 @@ const char* const GSplatSphericalHarmonicsLib = R"glsl(
                 int shOrder, 
                 bool onlySH)
     {
-        dir = -dir;
-
         float x = dir.x;
         float y = dir.y;
         float z = dir.z;


### PR DESCRIPTION
AFAICT this dir flip just makes spherical harmonics appear incorrectly.